### PR TITLE
Add precompile substrate-utils module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,10 @@ panic = "unwind"
 [workspace]
 members = [
     "node",
-    "pallets/*",
     "runtime",
+    "pallets/motion",
+    "pallets/evm-utils",
+	"pallets/evm/precompile/substrate-utils",
 ]
 resolver = "2"
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parachain-magnet-node"
-version = "0.1.1"
+version = "0.1.3"
 authors = ["Anonymous"]
 description = "A scalable evm smart contract platform node, utilizing DOT as the gas fee."
 license = "Apache License 2.0"

--- a/pallets/evm/precompile/substrate-utils/Cargo.toml
+++ b/pallets/evm/precompile/substrate-utils/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+name = "pallet-precompile-substrate-utils"
+version = "0.1.0"
+authors = ["Alex Wang"]
+description = "precompile substrate-utils for Magnet."
+license = "Apache-2.0"
+homepage = "https://magnet.magport.io/"
+repository.workspace = true
+edition.workspace = true
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+# Substrate
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
+
+#Frontier FRAME
+pallet-evm = { version = "6.0.0-dev", git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.1.0", default-features = false }
+
+# Frontier Primitive
+fp-evm = { version = "3.0.0-dev", git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.1.0", default-features = false }
+fp-account = { version = "1.0.0-dev", git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.1.0", default-features = false }
+precompile-utils = { git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.1.0", default-features = false }
+
+[dev-dependencies]
+pallet-evm-test-vector-support = { git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.1.0", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	# Substrate
+	"sp-io/std",
+	"sp-core/std",
+	"sp-runtime/std",
+	"frame-support/std",
+	# Frontier
+	"fp-evm/std",
+	"fp-account/std",
+	"precompile-utils/std",
+	#Frontier FRAME
+	"pallet-evm/std",
+]
+runtime-benchmarks = [
+	"frame-support/runtime-benchmarks",
+	"pallet-evm/runtime-benchmarks",
+]
+try-runtime = [
+	"frame-support/try-runtime",
+	"pallet-evm/try-runtime",
+]

--- a/pallets/evm/precompile/substrate-utils/README.md
+++ b/pallets/evm/precompile/substrate-utils/README.md
@@ -1,0 +1,13 @@
+# precompile-substrate-utils
+
+The evm-precompile-substrate-utils module provides procompile substrate Practical Functions, 
+
+
+## Interface
+
+### Functions
+
+'transfer_to_substrate' - transfer currency Dot from EVM address account in EVM to substrate address account.
+
+
+

--- a/pallets/evm/precompile/substrate-utils/src/lib.rs
+++ b/pallets/evm/precompile/substrate-utils/src/lib.rs
@@ -1,0 +1,135 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use alloc::{vec, vec::Vec};
+use core::marker::PhantomData;
+use fp_evm::{ExitError, ExitRevert, ExitSucceed, Precompile, PrecompileFailure};
+use fp_evm::{PrecompileHandle, PrecompileOutput, PrecompileResult};
+use frame_support::traits::{Currency, ExistenceRequirement};
+use pallet_evm::AddressMapping;
+use precompile_utils::prelude::*;
+use sp_core::{
+	crypto::{AccountId32, Ss58Codec},
+	Get, U256,
+};
+use sp_runtime::traits::UniqueSaturatedInto;
+
+struct MaxSize;
+impl Get<u32> for MaxSize {
+	fn get() -> u32 {
+		256u32
+	}
+}
+
+pub struct SubstrateUtils<T> {
+	_marker: PhantomData<T>,
+}
+
+impl<T: pallet_evm::Config> Precompile for SubstrateUtils<T>
+where
+	U256: UniqueSaturatedInto<pallet_evm::BalanceOf<T>>,
+	T::AccountId: From<AccountId32>,
+{
+	fn execute(handle: &mut impl PrecompileHandle) -> PrecompileResult {
+		let selector = handle.read_u32_selector()?;
+
+		let selector_bytes: [u8; 4] = sp_io::hashing::keccak_256(b"transferToSubstrate(string)")
+			[0..4]
+			.try_into()
+			.map_err(|_| PrecompileFailure::Error {
+				exit_status: ExitError::Other(
+					"get transferToSubstrate selector_bytes failed".into(),
+				),
+			})?;
+		let transfer_selector = u32::from_be_bytes(selector_bytes);
+
+		match selector {
+			a if a == transfer_selector => _ = Self::transfer_to_substrate(handle)?,
+			_ => {
+				return Err(PrecompileFailure::Revert {
+					exit_status: ExitRevert::Reverted,
+					output: "Not find the selector error".into(),
+				})
+			},
+		}
+
+		Ok(PrecompileOutput { exit_status: ExitSucceed::Returned, output: Vec::new() })
+	}
+}
+
+impl<T: pallet_evm::Config> SubstrateUtils<T>
+where
+	U256: UniqueSaturatedInto<pallet_evm::BalanceOf<T>>,
+	T::AccountId: From<AccountId32>,
+{
+	fn transfer_to_substrate(handle: &mut impl PrecompileHandle) -> PrecompileResult {
+		let code_address = handle.code_address();
+		let input = handle.input();
+		let target_gas = handle.gas_limit();
+		let context = handle.context();
+
+		let caller = context.caller.clone();
+		let code_origin = T::AddressMapping::into_account_id(code_address);
+		let value = context.apparent_value;
+		let to_who_bstr = solidity::decode_arguments::<BoundedString<MaxSize>>(&input[4..])?;
+
+		if handle.is_static() {
+			return Err(PrecompileFailure::Error {
+				exit_status: ExitError::Other("Can't be static call error".into()),
+			});
+		}
+
+		let to_who_ss58 =
+			String::try_from(to_who_bstr.clone()).map_err(|_| PrecompileFailure::Error {
+				exit_status: ExitError::Other("String try from BoundedString failed".into()),
+			})?;
+
+		let to_who_id32 =
+			AccountId32::from_ss58check(&to_who_ss58).map_err(|_| PrecompileFailure::Error {
+				exit_status: ExitError::Other("AccountId32 from ss58check(string) failed".into()),
+			})?;
+
+		let to_who: <T>::AccountId = to_who_id32.clone().into();
+
+		//Base gas 3000 + write balance gas 5000 + write substrate gas
+		//write balance from zero 20000 gas and
+		//a 15,000 gas refund when a non-zero value is set to zero.
+		let mut gas_cost: u64 = 3000 + 5000 + 20000;
+		let log_costs = precompile_utils::evm::costs::log_costs(4, 32)?;
+
+		gas_cost = gas_cost + log_costs;
+
+		if let Some(gas) = target_gas {
+			if gas <= gas_cost {
+				return Err(PrecompileFailure::Error { exit_status: ExitError::OutOfGas });
+			}
+		}
+
+		handle.record_cost(gas_cost)?;
+
+		T::Currency::transfer(
+			&code_origin,
+			&to_who,
+			value.unique_saturated_into(),
+			ExistenceRequirement::AllowDeath,
+		)
+		.map_err(|_| PrecompileFailure::Error {
+			exit_status: ExitError::Other("Currency transfer failed".into()),
+		})?;
+
+		let event = sp_io::hashing::keccak_256(b"TransferOut(address,string,uint256,string)");
+		let ss58_bytes = to_who_ss58.as_bytes();
+		let ss58_hash = sp_io::hashing::keccak_256(ss58_bytes);
+		let ss58_arg = solidity::encode_arguments::<BoundedString<MaxSize>>(to_who_bstr);
+		let mut value_bytes: [u8; 32] = [0u8; 32];
+		value.to_big_endian(&mut value_bytes);
+		handle.log(
+			code_address,
+			vec![event.into(), caller.into(), ss58_hash.into(), value_bytes.into()],
+			ss58_arg.into(),
+		)?;
+
+		Ok(PrecompileOutput { exit_status: ExitSucceed::Returned, output: Vec::new() })
+	}
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parachain-magnet-runtime"
-version = "0.1.1"
+version = "0.1.3"
 authors = ["Anonymous"]
 description = "A scalable evm smart contract platform runtime, utilizing DOT as the gas fee."
 license = "Apache License 2.0"
@@ -25,7 +25,7 @@ smallvec = "1.11.0"
 pallet-parachain-template = { path = "../pallets/template", default-features = false }
 pallet-motion = { path = "../pallets/motion", default-features = false }
 pallet-evm-utils = { path = "../pallets/evm-utils", default-features = false }
-
+pallet-precompile-substrate-utils = { path = "../pallets/evm/precompile/substrate-utils", default-features = false }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false, optional = true}
@@ -167,6 +167,7 @@ std = [
 	"pallet-motion/std",
 	"fp-self-contained/std",
 	"pallet-evm-utils/std",
+	"pallet-precompile-substrate-utils/std",
 ]
 
 runtime-benchmarks = [
@@ -190,6 +191,7 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"pallet-evm-utils/runtime-benchmarks",
+	"pallet-precompile-substrate-utils/runtime-benchmarks",
 ]
 
 try-runtime = [
@@ -216,6 +218,7 @@ try-runtime = [
 	"polkadot-runtime-common/try-runtime",
 	"sp-runtime/try-runtime",
 	"pallet-evm-utils/try-runtime",
+	"pallet-precompile-substrate-utils/try-runtime",
 ]
 
 experimental = [ "pallet-aura/experimental" ]

--- a/runtime/src/precompiles.rs
+++ b/runtime/src/precompiles.rs
@@ -1,12 +1,14 @@
 use pallet_evm::{
 	IsPrecompileResult, Precompile, PrecompileHandle, PrecompileResult, PrecompileSet,
 };
-use sp_core::H160;
+use sp_core::{crypto::AccountId32, H160, U256};
+use sp_runtime::traits::UniqueSaturatedInto;
 use sp_std::marker::PhantomData;
 
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
+use pallet_precompile_substrate_utils::SubstrateUtils;
 
 pub struct FrontierPrecompiles<R>(PhantomData<R>);
 
@@ -17,13 +19,15 @@ where
 	pub fn new() -> Self {
 		Self(Default::default())
 	}
-	pub fn used_addresses() -> [H160; 7] {
-		[hash(1), hash(2), hash(3), hash(4), hash(5), hash(1024), hash(1025)]
+	pub fn used_addresses() -> [H160; 8] {
+		[hash(1), hash(2), hash(3), hash(4), hash(5), hash(1024), hash(1025), hash(2048)]
 	}
 }
 impl<R> PrecompileSet for FrontierPrecompiles<R>
 where
 	R: pallet_evm::Config,
+	R::AccountId: From<AccountId32>,
+	U256: UniqueSaturatedInto<pallet_evm::BalanceOf<R>>,
 {
 	fn execute(&self, handle: &mut impl PrecompileHandle) -> Option<PrecompileResult> {
 		match handle.code_address() {
@@ -36,6 +40,7 @@ where
 			// Non-Frontier specific nor Ethereum precompiles :
 			a if a == hash(1024) => Some(Sha3FIPS256::execute(handle)),
 			a if a == hash(1025) => Some(ECRecoverPublicKey::execute(handle)),
+			a if a == hash(2048) => Some(SubstrateUtils::<R>::execute(handle)),
 			_ => None,
 		}
 	}


### PR DESCRIPTION
The precompile substrate-utils module provides substrate practical functions for EVM. The first function is transferToSubstrate which transfer currency Dot from EVM address account in EVM to substrate address account.

close #11 