### PR TITLE
Add pallet pot and pallet assurance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,20 @@ panic = "unwind"
 members = [
     "node",
     "runtime",
+	"primitives/system",
     "pallets/motion",
     "pallets/evm-utils",
 	"pallets/evm/precompile/substrate-utils",
+	"pallets/pot/runtime-api",
+	"pallets/pot/rpc",
+	"pallets/pot",
+	"pallets/assurance",
 ]
 resolver = "2"
 
 [workspace.package]
-authors = ["Anonymous"]
+authors = ["Magport/Magnet team"]
 edition = "2021"
 homepage = "https://magnet.magport.io/"
-license = "Unlicense"
+license = "Apache License 2.0"
 repository = "https://github.com/Magport/Magnet"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3.28"
 
 # Local
 parachain-magnet-runtime = { path = "../runtime" }
+pallet-pot-rpc = { path = "../pallets/pot/rpc" }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
@@ -59,7 +60,7 @@ sp-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", bran
 sp-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 substrate-prometheus-endpoint = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-sp-std = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
+sp-std = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 # Polkadot
 polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", features = ["rococo-native"] }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -316,5 +316,6 @@ fn testnet_genesis(
 		ethereum: Default::default(),
 		dynamic_fee: Default::default(),
 		base_fee: Default::default(),
+		assurance: Default::default(),
 	}
 }

--- a/pallets/assets-bridge/Cargo.toml
+++ b/pallets/assets-bridge/Cargo.toml
@@ -42,5 +42,6 @@ std = [
 
 	"pallet-assets/std",
 	"pallet-evm/std",
+	"pallet-balances/std",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/assurance/Cargo.toml
+++ b/pallets/assurance/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "pallet-evm-utils"
+name = "pallet-assurance"
 version = "0.1.0"
 authors = ["Alex Wang"]
-description = "EVM utils for Magnet."
+description = "Ensuring block production as parathread."
 license = "Apache-2.0"
 homepage = "https://magnet.magport.io/"
 repository.workspace = true
@@ -15,20 +15,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
 scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
+mp-system = { path = "../../primitives/system", default-features = false }
+pallet-pot = { path = "../pot", default-features = false }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false, optional = true}
 frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
 frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
-
-#Frontier FRAME
-pallet-evm-chain-id = { version = "1.0.0-dev", git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.1.0", default-features = false}
-pallet-evm = { version = "6.0.0-dev", git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.1.0", default-features = false}
-
-# Frontier Primitive
-fp-evm = { version = "3.0.0-dev", git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.1.0", default-features = false}
-fp-account = { version = "1.0.0-dev", git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.1.0", default-features = false}
+sp-std = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
+cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false, features = ["parameterized-consensus-hook"] }
 
 [dev-dependencies]
 serde = { version = "1.0.188" }
@@ -37,9 +33,9 @@ serde = { version = "1.0.188" }
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
 sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
+cumulus-primitives-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
 pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
 pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
-
 
 [features]
 default = [ "std" ]
@@ -48,7 +44,7 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
-	"pallet-evm/runtime-benchmarks",
+	"cumulus-pallet-parachain-system/runtime-benchmarks",
 ]
 std = [
 	"codec/std",
@@ -56,17 +52,20 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"pallet-balances/std",
-	"pallet-timestamp/std",	
+	"pallet-timestamp/std",
 	"scale-info/std",
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"pallet-evm/std",
+	"sp-std/std",
+	"cumulus-pallet-parachain-system/std",
+	"cumulus-primitives-core/std",
+	"mp-system/std",
+	"pallet-pot/std",
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
-	"pallet-evm/try-runtime",
+	"cumulus-pallet-parachain-system/try-runtime",
 ]
-forbid-evm-reentrancy = ["pallet-evm/forbid-evm-reentrancy"]

--- a/pallets/assurance/README.md
+++ b/pallets/assurance/README.md
@@ -1,0 +1,13 @@
+# EVM-Utils Pallet
+
+The Assurance Pallet ensuring block production as parathread.
+
+
+## Interface
+
+### Dispatchable Functions
+
+- `deposit` - deposit currency Dot to systems and special accounts.
+
+
+

--- a/pallets/assurance/src/lib.rs
+++ b/pallets/assurance/src/lib.rs
@@ -1,0 +1,184 @@
+// Copyright (C) Magnet.
+// This file is part of Magnet.
+
+// Magnet is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Magnet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Magnet.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+use frame_support::traits::{Currency, Get};
+use frame_support::{sp_runtime, weights::Weight};
+use mp_system::Liquidate;
+pub use pallet::*;
+use sp_core::crypto::AccountId32;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use cumulus_pallet_parachain_system::{RelaychainDataProvider, RelaychainStateProvider};
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config:
+		pallet_pot::Config + cumulus_pallet_parachain_system::Config + frame_system::Config
+	{
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		/// System pot name
+		type SystemPotName: Get<&'static str>;
+		/// Liquidate type for liquidate
+		type Liquidate: Liquidate;
+		/// Threshod for force bid coretime and force liquidate
+		type DefaultBidThreshold: Get<u32>;
+		type DefaultLiquidateThreshold: Get<BalanceOf<Self>>;
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		NewBidThreshold(u32),
+		NewLiquidateThreshold(BalanceOf<T>),
+		ForceLiquidate(BalanceOf<T>),
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {}
+
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		pub bid_threshold: u32,
+		pub liquidate_threshold: BalanceOf<T>,
+		#[serde(skip)]
+		pub _marker: PhantomData<T>,
+	}
+
+	impl<T: Config> GenesisConfig<T> {
+		pub fn new(bid_threshold: u32, liquidate_threshold: BalanceOf<T>) -> Self {
+			Self { bid_threshold, liquidate_threshold, _marker: PhantomData }
+		}
+	}
+
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			Self {
+				bid_threshold: T::DefaultBidThreshold::get(),
+				liquidate_threshold: T::DefaultLiquidateThreshold::get(),
+				_marker: PhantomData,
+			}
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
+		fn build(&self) {
+			<BidThreshold<T>>::put(self.bid_threshold);
+			<LiquidateThreshold<T>>::put(self.liquidate_threshold);
+		}
+	}
+
+	#[pallet::type_value]
+	pub fn DefaultBidThreshold<T: Config>() -> u32 {
+		T::DefaultBidThreshold::get()
+	}
+
+	#[pallet::storage]
+	pub type BidThreshold<T> = StorageValue<_, u32, ValueQuery, DefaultBidThreshold<T>>;
+
+	#[pallet::type_value]
+	pub fn DefaultLiquidateThreshold<T: Config>() -> BalanceOf<T> {
+		T::DefaultLiquidateThreshold::get()
+	}
+
+	#[pallet::storage]
+	pub type LiquidateThreshold<T> =
+		StorageValue<_, BalanceOf<T>, ValueQuery, DefaultLiquidateThreshold<T>>;
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T>
+	where
+		T::AccountId: From<AccountId32>,
+	{
+		fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
+			let mut weight = Weight::zero();
+
+			if let Ok(balance) = pallet_pot::Pallet::<T>::balance_of(T::SystemPotName::get()) {
+				if balance < LiquidateThreshold::<T>::get() {
+					weight += T::Liquidate::liquidate();
+					Self::deposit_event(Event::ForceLiquidate(balance));
+				}
+				weight += T::DbWeight::get().writes(1);
+			}
+			weight += T::DbWeight::get().reads(2);
+
+			weight
+		}
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
+		#[pallet::weight(10_000 + T::DbWeight::get().writes(1).ref_time())]
+		pub fn set_bid_threshold(origin: OriginFor<T>, blocknumber: u32) -> DispatchResult {
+			ensure_root(origin)?;
+			let _ = Self::set_bid_threshold_inner(blocknumber);
+			Self::deposit_event(Event::NewBidThreshold(blocknumber));
+			Ok(())
+		}
+
+		#[pallet::call_index(1)]
+		#[pallet::weight(10_000 + T::DbWeight::get().writes(1).ref_time())]
+		pub fn set_liquidate_threshold(
+			origin: OriginFor<T>,
+			balance: BalanceOf<T>,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+			let _ = Self::set_liquidate_threshold_inner(balance);
+			Self::deposit_event(Event::NewLiquidateThreshold(balance));
+			Ok(())
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		pub fn set_bid_threshold_inner(value: u32) -> Weight {
+			<BidThreshold<T>>::put(value);
+			T::DbWeight::get().writes(1)
+		}
+
+		pub fn set_liquidate_threshold_inner(value: BalanceOf<T>) -> Weight {
+			<LiquidateThreshold<T>>::put(value);
+			T::DbWeight::get().writes(1)
+		}
+
+		pub fn on_relaychain(blocknumber: u32) -> i32 {
+			let last_relay_block_number =
+				RelaychainDataProvider::<T>::current_relay_chain_state().number;
+			if blocknumber > BidThreshold::<T>::get() + u32::from(last_relay_block_number) {
+				return 1;
+			}
+
+			0
+		}
+	}
+}
+
+pub type BalanceOf<T> = <<T as pallet_pot::Config>::Currency as Currency<
+	<T as frame_system::Config>::AccountId,
+>>::Balance;

--- a/pallets/assurance/src/mock.rs
+++ b/pallets/assurance/src/mock.rs
@@ -1,0 +1,243 @@
+// Copyright (C) Magnet.
+// This file is part of Magnet.
+
+// Magnet is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Magnet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Magnet.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+
+use cumulus_pallet_parachain_system::{
+	consensus_hook::{ConsensusHook, UnincludedSegmentCapacity},
+	relay_state_snapshot::RelayChainStateProof,
+};
+use cumulus_primitives_core::ParaId;
+use frame_support::{
+	dispatch::DispatchClass,
+	parameter_types,
+	traits::{ConstU32, ConstU64, Get},
+	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
+};
+use pallet_pot::PotNameBtreemap;
+use sp_core::{crypto::AccountId32, H256};
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
+};
+use sp_std::collections::btree_map::BTreeMap;
+use sp_std::{cell::RefCell, num::NonZeroU32};
+//use frame_system::pallet_prelude::*;
+
+use crate as pallet_assurance;
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+	pub enum Test {
+		System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
+		ParachainSystem: cumulus_pallet_parachain_system::{Pallet, Call, Config<T>, Storage, Event<T>},
+		Pot: pallet_pot::{Pallet, Call, Storage, Event<T>},
+		Assurance: pallet_assurance::{Pallet, Call, Config<T>, Storage, Event<T>},
+	}
+);
+
+parameter_types! {
+	pub(crate) static ExtrinsicBaseWeight: Weight = Weight::zero();
+	pub(crate) static ExistentialDeposit: u64 = 0;
+}
+
+pub struct BlockWeights;
+impl Get<frame_system::limits::BlockWeights> for BlockWeights {
+	fn get() -> frame_system::limits::BlockWeights {
+		frame_system::limits::BlockWeights::builder()
+			.base_block(Weight::zero())
+			.for_class(DispatchClass::all(), |weights| {
+				weights.base_extrinsic = ExtrinsicBaseWeight::get().into();
+			})
+			.for_class(DispatchClass::non_mandatory(), |weights| {
+				weights.max_total = Weight::from_parts(1024, u64::MAX).into();
+			})
+			.build_or_panic()
+	}
+}
+
+pub type AccountId = AccountId32;
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = BlockWeights;
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type Nonce = u64;
+	type RuntimeCall = RuntimeCall;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Block = Block;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<u64>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
+	type MaxConsumers = ConstU32<16>;
+}
+
+impl pallet_balances::Config for Test {
+	type Balance = u64;
+	type RuntimeEvent = RuntimeEvent;
+	type DustRemoval = ();
+	type ExistentialDeposit = ConstU64<1>;
+	type AccountStore = System;
+	type MaxLocks = ();
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 8];
+	type WeightInfo = ();
+	type FreezeIdentifier = ();
+	type MaxFreezes = ();
+	type RuntimeHoldReason = ();
+	type MaxHolds = ();
+}
+
+parameter_types! {
+	pub const MinimumPeriod: u64 = 1;
+}
+
+impl pallet_timestamp::Config for Test {
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
+}
+
+/// We allow for 0.5 of a second of compute with a 12 second average block time.
+const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
+	WEIGHT_REF_TIME_PER_SECOND.saturating_div(2),
+	cumulus_primitives_core::relay_chain::MAX_POV_SIZE as u64,
+);
+
+parameter_types! {
+	pub const ReservedXcmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+	pub const ReservedDmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+	pub const ParachainId: ParaId = ParaId::new(200);
+}
+
+impl cumulus_pallet_parachain_system::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type OnSystemEvent = ();
+	type SelfParaId = ParachainId;
+	type OutboundXcmpMessageSource = ();
+	type DmpMessageHandler = ();
+	type ReservedDmpWeight = ReservedDmpWeight;
+	type XcmpMessageHandler = ();
+	type ReservedXcmpWeight = ReservedXcmpWeight;
+	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::AnyRelayNumber;
+	type ConsensusHook = TestConsensusHook;
+}
+
+std::thread_local! {
+	pub static CONSENSUS_HOOK: RefCell<Box<dyn Fn(&RelayChainStateProof) -> (Weight, UnincludedSegmentCapacity)>>
+		= RefCell::new(Box::new(|_| (Weight::zero(), NonZeroU32::new(1).unwrap().into())));
+}
+
+pub struct TestConsensusHook;
+
+impl ConsensusHook for TestConsensusHook {
+	fn on_state_proof(s: &RelayChainStateProof) -> (Weight, UnincludedSegmentCapacity) {
+		CONSENSUS_HOOK.with(|f| f.borrow_mut()(s))
+	}
+}
+
+parameter_types! {
+	pub const PotNames: [&'static str;3] = ["system", "treasury", "maintenance"];
+	pub Pots: BTreeMap<String, AccountId> = pallet_pot
+											::HashedPotNameBtreemap
+											::<Test, pallet_pot::HashedPotNameMapping<BlakeTwo256>>
+											::pots_btreemap(&(PotNames::get()));
+}
+
+impl pallet_pot::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type PotNameMapping = pallet_pot::HashedPotNameMapping<BlakeTwo256>;
+	type Currency = Balances;
+	type Pots = Pots;
+}
+
+parameter_types! {
+	pub const SystemPotName: &'static str = "system";
+}
+
+impl pallet_assurance::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type SystemPotName = SystemPotName;
+	type Liquidate = ();
+	type DefaultBidThreshold = ConstU32<8u32>;
+	type DefaultLiquidateThreshold = ConstU64<100_000_000_000_000>;
+}
+
+pub const ALICE: AccountId32 = AccountId32::new([21u8; 32]);
+
+pub struct ExtBuilder {
+	existential_deposit: u64,
+}
+
+impl Default for ExtBuilder {
+	fn default() -> Self {
+		Self { existential_deposit: 1 }
+	}
+}
+
+impl ExtBuilder {
+	pub fn existential_deposit(mut self, existential_deposit: u64) -> Self {
+		self.existential_deposit = existential_deposit;
+		self
+	}
+	pub fn set_associated_consts(&self) {
+		EXISTENTIAL_DEPOSIT.with(|v| *v.borrow_mut() = self.existential_deposit);
+	}
+	pub fn build(self) -> sp_io::TestExternalities {
+		self.set_associated_consts();
+		let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+		pallet_balances::GenesisConfig::<Test> { balances: vec![] }
+			.assimilate_storage(&mut t)
+			.unwrap();
+		pallet_assurance::GenesisConfig::<Test> {
+			bid_threshold: 8u32,
+			liquidate_threshold: 100_000_000_000_000u64,
+			_marker: Default::default(),
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+		cumulus_pallet_parachain_system::GenesisConfig::<Test>::default()
+			.build_storage()
+			.unwrap();
+		let mut ext = sp_io::TestExternalities::new(t);
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+}
+
+pub(crate) fn last_event() -> RuntimeEvent {
+	frame_system::Pallet::<Test>::events().pop().expect("Event expected").event
+}
+
+pub(crate) fn expect_event<E: Into<RuntimeEvent>>(e: E) {
+	assert_eq!(last_event(), e.into());
+}

--- a/pallets/assurance/src/tests.rs
+++ b/pallets/assurance/src/tests.rs
@@ -1,0 +1,95 @@
+// Copyright (C) Magnet.
+// This file is part of Magnet.
+
+// Magnet is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Magnet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Magnet.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+
+use crate as pallet_assurance;
+use crate::mock::*;
+use cumulus_pallet_parachain_system::{RelaychainDataProvider, RelaychainStateProvider};
+use frame_support::assert_ok;
+use frame_support::traits::Hooks;
+use Event as AssuranceEvent;
+
+#[test]
+fn set_bid_threshold_works() {
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let default_bid_threshold = pallet_assurance::BidThreshold::<Test>::get();
+		assert_eq!(default_bid_threshold, 8u32);
+		assert_ok!(Assurance::set_bid_threshold(RuntimeOrigin::root(), 12u32));
+		expect_event(AssuranceEvent::NewBidThreshold(12u32));
+		assert_eq!(pallet_assurance::BidThreshold::<Test>::get(), 12u32);
+	})
+}
+
+#[test]
+fn set_liquidate_threshold_works() {
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let default_liquidate_threshold = pallet_assurance::LiquidateThreshold::<Test>::get();
+		assert_eq!(default_liquidate_threshold, 100_000_000_000_000u64);
+		assert_ok!(Assurance::set_liquidate_threshold(
+			RuntimeOrigin::root(),
+			200_000_000_000_000u64
+		));
+		expect_event(AssuranceEvent::NewLiquidateThreshold(200_000_000_000_000u64));
+		assert_eq!(pallet_assurance::LiquidateThreshold::<Test>::get(), 200_000_000_000_000u64);
+	})
+}
+
+#[test]
+fn on_relaychain_works() {
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let parent_relay_blocknumber =
+			u32::from(RelaychainDataProvider::<Test>::current_relay_chain_state().number);
+		let bid_threshold = pallet_assurance::BidThreshold::<Test>::get();
+		assert_eq!(bid_threshold, 8u32);
+
+		let on_relay_return = Assurance::on_relaychain(parent_relay_blocknumber);
+		assert_eq!(on_relay_return, 0);
+
+		let on_relay_return =
+			Assurance::on_relaychain(parent_relay_blocknumber + bid_threshold + 1u32);
+		assert_eq!(on_relay_return, 1);
+	})
+}
+
+#[test]
+fn force_liquidate_works() {
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		assert_ok!(Pot::ensure_pot("system"));
+		let pot_system = Pot::ensure_pot("system").unwrap();
+		let liquidate_threshold = pallet_assurance::LiquidateThreshold::<Test>::get();
+		assert_eq!(liquidate_threshold, 100_000_000_000_000u64);
+
+		let _ = Balances::deposit_creating(&pot_system, liquidate_threshold);
+
+		System::on_finalize(System::block_number());
+		System::reset_events();
+		System::set_block_number(System::block_number() + 1);
+		System::on_initialize(System::block_number());
+		Assurance::on_initialize(System::block_number());
+		System::on_finalize(System::block_number());
+
+		assert_ok!(Pot::withdraw(RuntimeOrigin::root(), ALICE, "system".to_string(), 1));
+
+		System::on_finalize(System::block_number());
+		System::reset_events();
+		System::set_block_number(System::block_number() + 1);
+		System::on_initialize(System::block_number());
+		Assurance::on_initialize(System::block_number());
+		expect_event(AssuranceEvent::ForceLiquidate(liquidate_threshold - 1));
+		System::on_finalize(System::block_number());
+	})
+}

--- a/pallets/evm-utils/src/lib.rs
+++ b/pallets/evm-utils/src/lib.rs
@@ -16,6 +16,11 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
 use frame_support::traits::Currency;
 pub use pallet::*;
 use pallet_evm::{AddressMapping, BalanceOf};

--- a/pallets/evm-utils/src/mock.rs
+++ b/pallets/evm-utils/src/mock.rs
@@ -1,0 +1,244 @@
+// Copyright (C) Magnet.
+// This file is part of Magnet.
+
+// Magnet is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Magnet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Magnet.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+
+use frame_support::{
+	dispatch::DispatchClass,
+	parameter_types,
+	traits::{ConstU32, ConstU64, FindAuthor, Get},
+	weights::Weight,
+	ConsensusEngineId,
+};
+use pallet_evm::{
+	EnsureAddressNever, EnsureAddressRoot, FeeCalculator, IsPrecompileResult, PrecompileHandle,
+	PrecompileResult, PrecompileSet,
+};
+use sp_core::{crypto::AccountId32, H256, U256};
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
+};
+use std::str::FromStr;
+
+//use frame_system::pallet_prelude::*;
+
+use crate as pallet_evm_util;
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+	pub enum Test {
+		System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
+		EVM: pallet_evm::{Pallet, Call, Storage, Config<T>, Event<T>},
+		EvmUtil: pallet_evm_util::{Pallet, Call, Storage, Event<T>},
+	}
+);
+
+parameter_types! {
+	pub(crate) static ExtrinsicBaseWeight: Weight = Weight::zero();
+	pub(crate) static ExistentialDeposit: u64 = 0;
+}
+
+pub struct BlockWeights;
+impl Get<frame_system::limits::BlockWeights> for BlockWeights {
+	fn get() -> frame_system::limits::BlockWeights {
+		frame_system::limits::BlockWeights::builder()
+			.base_block(Weight::zero())
+			.for_class(DispatchClass::all(), |weights| {
+				weights.base_extrinsic = ExtrinsicBaseWeight::get().into();
+			})
+			.for_class(DispatchClass::non_mandatory(), |weights| {
+				weights.max_total = Weight::from_parts(1024, u64::MAX).into();
+			})
+			.build_or_panic()
+	}
+}
+
+pub type AccountId = AccountId32;
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = BlockWeights;
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type Nonce = u64;
+	type RuntimeCall = RuntimeCall;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Block = Block;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<u64>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
+}
+
+impl pallet_balances::Config for Test {
+	type Balance = u64;
+	type RuntimeEvent = RuntimeEvent;
+	type DustRemoval = ();
+	type ExistentialDeposit = ConstU64<1>;
+	type AccountStore = System;
+	type MaxLocks = ();
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 8];
+	type WeightInfo = ();
+	type FreezeIdentifier = ();
+	type MaxFreezes = ();
+	type RuntimeHoldReason = ();
+	type MaxHolds = ();
+}
+
+parameter_types! {
+	pub const MinimumPeriod: u64 = 1;
+}
+
+impl pallet_timestamp::Config for Test {
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
+}
+
+/// Example PrecompileSet with only Identity precompile.
+pub struct MockPrecompileSet;
+
+impl PrecompileSet for MockPrecompileSet {
+	/// Tries to execute a precompile in the precompile set.
+	/// If the provided address is not a precompile, returns None.
+	fn execute(&self, _: &mut impl PrecompileHandle) -> Option<PrecompileResult> {
+		None
+	}
+
+	/// Check if the given address is a precompile. Should only be called to
+	/// perform the check while not executing the precompile afterward, since
+	/// `execute` already performs a check internally.
+	fn is_precompile(&self, address: H160, _gas: u64) -> IsPrecompileResult {
+		IsPrecompileResult::Answer {
+			is_precompile: address == H160::from_low_u64_be(1),
+			extra_cost: 0,
+		}
+	}
+}
+
+pub struct FixedGasPrice;
+impl FeeCalculator for FixedGasPrice {
+	fn min_gas_price() -> (U256, Weight) {
+		// Return some meaningful gas price and weight
+		(1_000_000_000u128.into(), Weight::from_parts(7u64, 0))
+	}
+}
+
+pub struct FindAuthorTruncated;
+impl FindAuthor<H160> for FindAuthorTruncated {
+	fn find_author<'a, I>(_digests: I) -> Option<H160>
+	where
+		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
+	{
+		Some(H160::from_str("1234500000000000000000000000000000000000").unwrap())
+	}
+}
+
+const BLOCK_GAS_LIMIT: u64 = 75_000_000;
+const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
+
+parameter_types! {
+	pub BlockGasLimit: U256 = U256::from(BLOCK_GAS_LIMIT);
+	pub const GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(MAX_POV_SIZE);
+	pub WeightPerGas: Weight = Weight::from_parts(20_000, 0);
+	pub MockPrecompiles: MockPrecompileSet = MockPrecompileSet;
+	//pub SuicideQuickClearLimit: u32 = 0;
+}
+
+impl pallet_evm::Config for Test {
+	type FeeCalculator = FixedGasPrice;
+	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
+	type WeightPerGas = WeightPerGas;
+	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
+	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;
+	type AddressMapping = pallet_evm::HashedAddressMapping<BlakeTwo256>;
+	type Currency = Balances;
+	type RuntimeEvent = RuntimeEvent;
+	type PrecompilesType = MockPrecompileSet;
+	type PrecompilesValue = MockPrecompiles;
+	type ChainId = ();
+	type BlockGasLimit = BlockGasLimit;
+	type Runner = pallet_evm::runner::stack::Runner<Self>;
+	type OnChargeTransaction = ();
+	type OnCreate = ();
+	type FindAuthor = FindAuthorTruncated;
+	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	//type SuicideQuickClearLimit = SuicideQuickClearLimit;
+	type Timestamp = Timestamp;
+	type WeightInfo = ();
+}
+
+impl pallet_evm_util::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+}
+
+pub const ALICE: AccountId32 = AccountId32::new([21u8; 32]);
+
+pub struct ExtBuilder {
+	existential_deposit: u64,
+}
+
+impl Default for ExtBuilder {
+	fn default() -> Self {
+		Self { existential_deposit: 1 }
+	}
+}
+
+impl ExtBuilder {
+	pub fn existential_deposit(mut self, existential_deposit: u64) -> Self {
+		self.existential_deposit = existential_deposit;
+		self
+	}
+	pub fn set_associated_consts(&self) {
+		EXISTENTIAL_DEPOSIT.with(|v| *v.borrow_mut() = self.existential_deposit);
+	}
+	pub fn build(self) -> sp_io::TestExternalities {
+		self.set_associated_consts();
+		let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+		pallet_balances::GenesisConfig::<Test> { balances: vec![] }
+			.assimilate_storage(&mut t)
+			.unwrap();
+		let mut ext = sp_io::TestExternalities::new(t);
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+}
+
+pub(crate) fn last_event() -> RuntimeEvent {
+	frame_system::Pallet::<Test>::events().pop().expect("Event expected").event
+}
+
+pub(crate) fn expect_event<E: Into<RuntimeEvent>>(e: E) {
+	assert_eq!(last_event(), e.into());
+}

--- a/pallets/evm-utils/src/tests.rs
+++ b/pallets/evm-utils/src/tests.rs
@@ -1,0 +1,50 @@
+// Copyright (C) Magnet.
+// This file is part of Magnet.
+
+// Magnet is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Magnet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Magnet.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg(test)]
+
+use super::*;
+
+use crate::mock::*;
+use frame_support::assert_ok;
+use Event as EvmUtilEvent;
+
+#[test]
+fn transfer_to_evm_works() {
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let bob_evm: H160 = H160::from_low_u64_be(123_123_123_123_123);
+		let bob = <Test as pallet_evm::Config>::AddressMapping::into_account_id(bob_evm);
+		let _ = Balances::deposit_creating(&ALICE, 10_000_000_000_000);
+		let _ = Balances::deposit_creating(&bob, 6_000_000_000_000);
+
+		let (bob_evm_account, _) = EVM::account_basic(&bob_evm);
+
+		let alice_value_before = Balances::free_balance(&ALICE);
+		let bob_evm_value_before: u64 = bob_evm_account.balance.as_u64();
+
+		let transfer_value = 80_000_000_000;
+
+		assert_ok!(EvmUtil::transfer_to_evm(RuntimeOrigin::signed(ALICE), bob_evm, transfer_value));
+		expect_event(EvmUtilEvent::TransferedToEVM(bob_evm, transfer_value, ALICE));
+
+		let alice_value_after = Balances::free_balance(&ALICE);
+		assert_eq!(alice_value_before, alice_value_after + transfer_value);
+
+		let (bob_evm_account, _) = EVM::account_basic(&bob_evm);
+		let bob_evm_value_after: u64 = bob_evm_account.balance.as_u64();
+		assert_eq!(bob_evm_value_before + transfer_value, bob_evm_value_after);
+	})
+}

--- a/pallets/evm/precompile/substrate-utils/Cargo.toml
+++ b/pallets/evm/precompile/substrate-utils/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
+scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
+
 # Substrate
 sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
@@ -28,16 +31,24 @@ fp-account = { version = "1.0.0-dev", git = "https://github.com/paritytech/front
 precompile-utils = { git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.1.0", default-features = false }
 
 [dev-dependencies]
-pallet-evm-test-vector-support = { git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.1.0", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
+
 
 [features]
 default = ["std"]
 std = [
+	"codec/std",
+	"scale-info/std",
 	# Substrate
 	"sp-io/std",
 	"sp-core/std",
 	"sp-runtime/std",
+	"frame-system/std",
 	"frame-support/std",
+	"pallet-balances/std",
+	"pallet-timestamp/std",
 	# Frontier
 	"fp-evm/std",
 	"fp-account/std",

--- a/pallets/evm/precompile/substrate-utils/src/lib.rs
+++ b/pallets/evm/precompile/substrate-utils/src/lib.rs
@@ -1,5 +1,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
 extern crate alloc;
 
 use alloc::{vec, vec::Vec};

--- a/pallets/evm/precompile/substrate-utils/src/mock.rs
+++ b/pallets/evm/precompile/substrate-utils/src/mock.rs
@@ -1,0 +1,267 @@
+// Copyright (C) Magnet.
+// This file is part of Magnet.
+
+// Magnet is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Magnet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Magnet.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+
+use frame_support::{
+	dispatch::DispatchClass,
+	parameter_types,
+	traits::{ConstU32, ConstU64, FindAuthor, Get},
+	weights::Weight,
+	ConsensusEngineId,
+};
+use pallet_evm::{
+	EnsureAddressNever, EnsureAddressRoot, FeeCalculator, IsPrecompileResult, PrecompileHandle,
+	PrecompileResult, PrecompileSet,
+};
+pub use sp_core::{crypto::AccountId32, H160, H256, U256};
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
+};
+use std::str::FromStr;
+
+//use frame_system::pallet_prelude::*;
+
+use crate as pallet_precompile_substrate_utils;
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+	pub enum Test {
+		System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
+		EVM: pallet_evm::{Pallet, Call, Storage, Config<T>, Event<T>},
+	}
+);
+
+parameter_types! {
+	pub(crate) static ExtrinsicBaseWeight: Weight = Weight::zero();
+	pub(crate) static ExistentialDeposit: u64 = 0;
+}
+
+pub struct BlockWeights;
+impl Get<frame_system::limits::BlockWeights> for BlockWeights {
+	fn get() -> frame_system::limits::BlockWeights {
+		frame_system::limits::BlockWeights::builder()
+			.base_block(Weight::zero())
+			.for_class(DispatchClass::all(), |weights| {
+				weights.base_extrinsic = ExtrinsicBaseWeight::get().into();
+			})
+			.for_class(DispatchClass::non_mandatory(), |weights| {
+				weights.max_total = Weight::from_parts(1024, u64::MAX).into();
+			})
+			.build_or_panic()
+	}
+}
+
+pub type AccountId = AccountId32;
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = BlockWeights;
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type Nonce = u64;
+	type RuntimeCall = RuntimeCall;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Block = Block;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<u64>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
+}
+
+impl pallet_balances::Config for Test {
+	type Balance = u64;
+	type RuntimeEvent = RuntimeEvent;
+	type DustRemoval = ();
+	type ExistentialDeposit = ConstU64<1>;
+	type AccountStore = System;
+	type MaxLocks = ();
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 8];
+	type WeightInfo = ();
+	type FreezeIdentifier = ();
+	type MaxFreezes = ();
+	type RuntimeHoldReason = ();
+	type MaxHolds = ();
+}
+
+parameter_types! {
+	pub const MinimumPeriod: u64 = 1;
+}
+
+impl pallet_timestamp::Config for Test {
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
+}
+
+/// Example PrecompileSet with only Identity precompile.
+pub struct MockPrecompileSet<R>(PhantomData<R>);
+
+impl<R> MockPrecompileSet<R>
+where
+	R: pallet_evm::Config,
+{
+	pub fn new() -> Self {
+		Self(Default::default())
+	}
+	pub fn used_addresses() -> [H160; 2] {
+		[hash(1), hash(2048)]
+	}
+}
+
+impl<R> PrecompileSet for MockPrecompileSet<R>
+where
+	R: pallet_evm::Config,
+	R::AccountId: From<AccountId32>,
+	U256: UniqueSaturatedInto<pallet_evm::BalanceOf<R>>,
+{
+	/// Tries to execute a precompile in the precompile set.
+	/// If the provided address is not a precompile, returns None.
+	fn execute(&self, handle: &mut impl PrecompileHandle) -> Option<PrecompileResult> {
+		match handle.code_address() {
+			a if a == hash(2048) => {
+				Some(pallet_precompile_substrate_utils::SubstrateUtils::<R>::execute(handle))
+			},
+			_ => None,
+		}
+	}
+
+	/// Check if the given address is a precompile. Should only be called to
+	/// perform the check while not executing the precompile afterward, since
+	/// `execute` already performs a check internally.
+	fn is_precompile(&self, address: H160, _gas: u64) -> IsPrecompileResult {
+		IsPrecompileResult::Answer {
+			is_precompile: Self::used_addresses().contains(&address),
+			extra_cost: 0,
+		}
+	}
+}
+
+fn hash(a: u64) -> H160 {
+	H160::from_low_u64_be(a)
+}
+
+pub struct FixedGasPrice;
+impl FeeCalculator for FixedGasPrice {
+	fn min_gas_price() -> (U256, Weight) {
+		// Return some meaningful gas price and weight
+		(1_000_000_000u128.into(), Weight::from_parts(7u64, 0))
+	}
+}
+
+pub struct FindAuthorTruncated;
+impl FindAuthor<H160> for FindAuthorTruncated {
+	fn find_author<'a, I>(_digests: I) -> Option<H160>
+	where
+		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
+	{
+		Some(H160::from_str("1234500000000000000000000000000000000000").unwrap())
+	}
+}
+
+const BLOCK_GAS_LIMIT: u64 = 75_000_000;
+const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
+
+parameter_types! {
+	pub BlockGasLimit: U256 = U256::from(BLOCK_GAS_LIMIT);
+	pub const GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(MAX_POV_SIZE);
+	pub WeightPerGas: Weight = Weight::from_parts(20_000, 0);
+	pub MockPrecompiles: MockPrecompileSet<Test> = MockPrecompileSet::<_>::new();
+	//pub SuicideQuickClearLimit: u32 = 0;
+}
+
+impl pallet_evm::Config for Test {
+	type FeeCalculator = FixedGasPrice;
+	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
+	type WeightPerGas = WeightPerGas;
+	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
+	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;
+	type AddressMapping = pallet_evm::HashedAddressMapping<BlakeTwo256>;
+	type Currency = Balances;
+	type RuntimeEvent = RuntimeEvent;
+	type PrecompilesType = MockPrecompileSet<Self>;
+	type PrecompilesValue = MockPrecompiles;
+	type ChainId = ();
+	type BlockGasLimit = BlockGasLimit;
+	type Runner = pallet_evm::runner::stack::Runner<Self>;
+	type OnChargeTransaction = ();
+	type OnCreate = ();
+	type FindAuthor = FindAuthorTruncated;
+	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	//type SuicideQuickClearLimit = SuicideQuickClearLimit;
+	type Timestamp = Timestamp;
+	type WeightInfo = ();
+}
+
+pub const ALICE: AccountId32 = AccountId32::new([21u8; 32]);
+
+pub struct ExtBuilder {
+	existential_deposit: u64,
+}
+
+impl Default for ExtBuilder {
+	fn default() -> Self {
+		Self { existential_deposit: 1 }
+	}
+}
+
+impl ExtBuilder {
+	pub fn existential_deposit(mut self, existential_deposit: u64) -> Self {
+		self.existential_deposit = existential_deposit;
+		self
+	}
+	pub fn set_associated_consts(&self) {
+		EXISTENTIAL_DEPOSIT.with(|v| *v.borrow_mut() = self.existential_deposit);
+	}
+	pub fn build(self) -> sp_io::TestExternalities {
+		self.set_associated_consts();
+		let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+		pallet_balances::GenesisConfig::<Test> { balances: vec![] }
+			.assimilate_storage(&mut t)
+			.unwrap();
+		let mut ext = sp_io::TestExternalities::new(t);
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+}
+
+/*
+pub(crate) fn last_event() -> RuntimeEvent {
+	frame_system::Pallet::<Test>::events().pop().expect("Event expected").event
+}
+
+pub(crate) fn expect_event<E: Into<RuntimeEvent>>(e: E) {
+	assert_eq!(last_event(), e.into());
+}
+*/

--- a/pallets/evm/precompile/substrate-utils/src/tests.rs
+++ b/pallets/evm/precompile/substrate-utils/src/tests.rs
@@ -1,0 +1,357 @@
+// Copyright (C) Magnet.
+// This file is part of Magnet.
+
+// Magnet is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Magnet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Magnet.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg(test)]
+
+use super::*;
+
+use crate::mock::*;
+use frame_support::assert_ok;
+use pallet_evm::{CallInfo, Error, ExitError, ExitReason, Runner};
+
+struct MaxSize;
+impl Get<u32> for MaxSize {
+	fn get() -> u32 {
+		256u32
+	}
+}
+
+#[test]
+fn transfer_to_substrate_works() {
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let bob_evm: H160 = H160::from_low_u64_be(123_123_123_123_123);
+		let bob = <Test as pallet_evm::Config>::AddressMapping::into_account_id(bob_evm);
+		let _ = Balances::deposit_creating(&ALICE, 10_000_000_000_000_000);
+		let _ = Balances::deposit_creating(&bob, 6_000_000_000_000_000);
+
+		let (bob_evm_account, _) = EVM::account_basic(&bob_evm);
+
+		let alice_value_before = Balances::free_balance(&ALICE);
+		let bob_evm_value_before: u64 = bob_evm_account.balance.as_u64();
+		let transfer_value = 800_000_000_000_000u64;
+
+		let target: H160 = H160::from_low_u64_be(2048);
+
+		let alice_ss58_address = ALICE.to_ss58check();
+		let alice_ss58_bstring = <BoundedString<MaxSize>>::from(alice_ss58_address);
+
+		let selector_bytes: [u8; 4] = sp_io::hashing::keccak_256(b"transferToSubstrate(string)")
+			[0..4]
+			.try_into()
+			.unwrap();
+		let selector = u32::from_be_bytes(selector_bytes);
+		let call_data = solidity::encode_with_selector(selector, alice_ss58_bstring);
+
+		let is_transactional = true;
+		let validate = true;
+		let call_result = <Test as pallet_evm::Config>::Runner::call(
+			bob_evm,
+			target,
+			call_data,
+			transfer_value.into(),
+			91776,
+			Some(U256::from(1_000_000_000)),
+			Some(U256::default()),
+			Some(U256::from(0)),
+			Vec::new(),
+			is_transactional,
+			validate,
+			None,
+			None,
+			<Test as pallet_evm::Config>::config(),
+		);
+		assert_ok!(&call_result);
+		let call_result = call_result.unwrap();
+
+		let used_gas: u64;
+		match call_result {
+			CallInfo { exit_reason: ExitReason::Succeed(_), value: _, used_gas: gas, .. } => {
+				used_gas = gas.effective.as_u64();
+			},
+			CallInfo { exit_reason: reason, value: err_value, .. } => {
+				println!("error : {:?}", std::str::from_utf8(&err_value));
+				panic!("Call transferToSubstrate failed!({:?})", reason);
+			},
+		};
+
+		let alice_value_after = Balances::free_balance(&ALICE);
+		assert_eq!(alice_value_before + transfer_value, alice_value_after);
+		let gas_fee: u64 = used_gas * 1_000_000_000;
+		let (bob_evm_account, _) = EVM::account_basic(&bob_evm);
+		let bob_evm_value_after: u64 = bob_evm_account.balance.as_u64();
+		assert_eq!(bob_evm_value_before, bob_evm_value_after + transfer_value + gas_fee);
+	})
+}
+
+#[test]
+fn gas_not_enoght_error_works() {
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let bob_evm: H160 = H160::from_low_u64_be(123_123_123_123_123);
+		let bob = <Test as pallet_evm::Config>::AddressMapping::into_account_id(bob_evm);
+		let _ = Balances::deposit_creating(&ALICE, 10_000_000_000_000_000);
+		let _ = Balances::deposit_creating(&bob, 6_000_000_000_000_000);
+
+		let transfer_value = 800_000_000_000_000u64;
+
+		let target: H160 = H160::from_low_u64_be(2048);
+
+		let alice_ss58_address = ALICE.to_ss58check();
+		let alice_ss58_bstring = <BoundedString<MaxSize>>::from(alice_ss58_address);
+
+		let selector_bytes: [u8; 4] = sp_io::hashing::keccak_256(b"transferToSubstrate(string)")
+			[0..4]
+			.try_into()
+			.unwrap();
+		let selector = u32::from_be_bytes(selector_bytes);
+		let call_data = solidity::encode_with_selector(selector, alice_ss58_bstring);
+
+		let is_transactional = true;
+		let validate = true;
+		let call_result = <Test as pallet_evm::Config>::Runner::call(
+			bob_evm,
+			target,
+			call_data,
+			transfer_value.into(),
+			917,
+			Some(U256::from(1_000_000_000)),
+			Some(U256::default()),
+			Some(U256::from(0)),
+			Vec::new(),
+			is_transactional,
+			validate,
+			None,
+			None,
+			<Test as pallet_evm::Config>::config(),
+		);
+		assert!(call_result.is_err());
+		let err = call_result.unwrap_err().error;
+		match err {
+			Error::<Test>::GasLimitTooLow => assert!(true),
+			_ => panic!("Not GasLimitTooLow but {:?}", err),
+		}
+	})
+}
+
+#[test]
+fn gas_price_too_low_error_works() {
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let bob_evm: H160 = H160::from_low_u64_be(123_123_123_123_123);
+		let bob = <Test as pallet_evm::Config>::AddressMapping::into_account_id(bob_evm);
+		let _ = Balances::deposit_creating(&ALICE, 10_000_000_000_000_000);
+		let _ = Balances::deposit_creating(&bob, 6_000_000_000_000_000);
+
+		let transfer_value = 800_000_000_000_000u64;
+
+		let target: H160 = H160::from_low_u64_be(2048);
+
+		let alice_ss58_address = ALICE.to_ss58check();
+		let alice_ss58_bstring = <BoundedString<MaxSize>>::from(alice_ss58_address);
+
+		let selector_bytes: [u8; 4] = sp_io::hashing::keccak_256(b"transferToSubstrate(string)")
+			[0..4]
+			.try_into()
+			.unwrap();
+		let selector = u32::from_be_bytes(selector_bytes);
+		let call_data = solidity::encode_with_selector(selector, alice_ss58_bstring);
+
+		let is_transactional = true;
+		let validate = true;
+		let call_result = <Test as pallet_evm::Config>::Runner::call(
+			bob_evm,
+			target,
+			call_data,
+			transfer_value.into(),
+			91776,
+			Some(U256::from(1_000)),
+			Some(U256::default()),
+			Some(U256::from(0)),
+			Vec::new(),
+			is_transactional,
+			validate,
+			None,
+			None,
+			<Test as pallet_evm::Config>::config(),
+		);
+		assert!(call_result.is_err());
+		let err = call_result.unwrap_err().error;
+		match err {
+			Error::<Test>::GasPriceTooLow => assert!(true),
+			_ => panic!("Not GasPriceTooLow but {:?}", err),
+		}
+	})
+}
+
+#[test]
+fn balance_not_enoght_error_works() {
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let bob_evm: H160 = H160::from_low_u64_be(123_123_123_123_123);
+		let bob = <Test as pallet_evm::Config>::AddressMapping::into_account_id(bob_evm);
+		let _ = Balances::deposit_creating(&ALICE, 10_000_000_000_000_000);
+		let _ = Balances::deposit_creating(&bob, 6_000_000_000_000_000);
+
+		let transfer_value = 800_000_000_000_000_000u64;
+
+		let target: H160 = H160::from_low_u64_be(2048);
+
+		let alice_ss58_address = ALICE.to_ss58check();
+		let alice_ss58_bstring = <BoundedString<MaxSize>>::from(alice_ss58_address);
+
+		let selector_bytes: [u8; 4] = sp_io::hashing::keccak_256(b"transferToSubstrate(string)")
+			[0..4]
+			.try_into()
+			.unwrap();
+		let selector = u32::from_be_bytes(selector_bytes);
+		let call_data = solidity::encode_with_selector(selector, alice_ss58_bstring);
+
+		let is_transactional = true;
+		let validate = true;
+		let call_result = <Test as pallet_evm::Config>::Runner::call(
+			bob_evm,
+			target,
+			call_data,
+			transfer_value.into(),
+			91776,
+			Some(U256::from(1_000_000_000)),
+			Some(U256::default()),
+			Some(U256::from(0)),
+			Vec::new(),
+			is_transactional,
+			validate,
+			None,
+			None,
+			<Test as pallet_evm::Config>::config(),
+		);
+		assert!(call_result.is_err());
+		let err = call_result.unwrap_err().error;
+		match err {
+			Error::<Test>::BalanceLow => assert!(true),
+			_ => panic!("Not BalanceLow but {:?}", err),
+		}
+	})
+}
+
+#[test]
+fn selector_error_works() {
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let bob_evm: H160 = H160::from_low_u64_be(123_123_123_123_123);
+		let bob = <Test as pallet_evm::Config>::AddressMapping::into_account_id(bob_evm);
+		let _ = Balances::deposit_creating(&ALICE, 10_000_000_000_000_000);
+		let _ = Balances::deposit_creating(&bob, 6_000_000_000_000_000);
+
+		let transfer_value = 800_000_000_000_000u64;
+
+		let target: H160 = H160::from_low_u64_be(2048);
+
+		let alice_ss58_address = ALICE.to_ss58check();
+		let alice_ss58_bstring = <BoundedString<MaxSize>>::from(alice_ss58_address);
+
+		let selector_bytes: [u8; 4] = sp_io::hashing::keccak_256(b"123transferToSubstrate(string)")
+			[0..4]
+			.try_into()
+			.unwrap();
+		let selector = u32::from_be_bytes(selector_bytes);
+		let call_data = solidity::encode_with_selector(selector, alice_ss58_bstring);
+
+		let is_transactional = true;
+		let validate = true;
+		let call_result = <Test as pallet_evm::Config>::Runner::call(
+			bob_evm,
+			target,
+			call_data,
+			transfer_value.into(),
+			91776,
+			Some(U256::from(1_000_000_000)),
+			Some(U256::default()),
+			Some(U256::from(0)),
+			Vec::new(),
+			is_transactional,
+			validate,
+			None,
+			None,
+			<Test as pallet_evm::Config>::config(),
+		);
+		assert_ok!(&call_result);
+		let call_result = call_result.unwrap();
+
+		match call_result {
+			CallInfo { exit_reason: ExitReason::Succeed(_), value: _, used_gas: _, .. } => {
+				panic!("exit_reason must not Succeed!");
+			},
+			CallInfo { exit_reason: _, value: err_value, .. } => {
+				assert_eq!(err_value, "Not find the selector error".as_bytes().to_owned());
+			},
+		};
+	})
+}
+
+#[test]
+fn ss58address_error_works() {
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let bob_evm: H160 = H160::from_low_u64_be(123_123_123_123_123);
+		let bob = <Test as pallet_evm::Config>::AddressMapping::into_account_id(bob_evm);
+		let _ = Balances::deposit_creating(&ALICE, 10_000_000_000_000_000);
+		let _ = Balances::deposit_creating(&bob, 6_000_000_000_000_000);
+
+		let transfer_value = 800_000_000_000_000u64;
+
+		let target: H160 = H160::from_low_u64_be(2048);
+
+		//let alice_ss58_address = ALICE.to_ss58check();
+		let alice_ss58_bstring = <BoundedString<MaxSize>>::from("1234567890");
+
+		let selector_bytes: [u8; 4] = sp_io::hashing::keccak_256(b"transferToSubstrate(string)")
+			[0..4]
+			.try_into()
+			.unwrap();
+		let selector = u32::from_be_bytes(selector_bytes);
+		let call_data = solidity::encode_with_selector(selector, alice_ss58_bstring);
+
+		let is_transactional = true;
+		let validate = true;
+		let call_result = <Test as pallet_evm::Config>::Runner::call(
+			bob_evm,
+			target,
+			call_data,
+			transfer_value.into(),
+			91776,
+			Some(U256::from(1_000_000_000)),
+			Some(U256::default()),
+			Some(U256::from(0)),
+			Vec::new(),
+			is_transactional,
+			validate,
+			None,
+			None,
+			<Test as pallet_evm::Config>::config(),
+		);
+		assert_ok!(&call_result);
+		let call_result = call_result.unwrap();
+
+		match call_result {
+			CallInfo { exit_reason: ExitReason::Succeed(_), value: _, used_gas: _, .. } => {
+				panic!("exit_reason must not Succeed!");
+			},
+			CallInfo { exit_reason: reason, value: _, .. } => {
+				assert_eq!(
+					reason,
+					ExitReason::Error(ExitError::Other(std::borrow::Cow::Borrowed(
+						"AccountId32 from ss58check(string) failed"
+					)))
+				);
+			},
+		};
+	})
+}

--- a/pallets/pot/Cargo.toml
+++ b/pallets/pot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "pallet-evm-utils"
+name = "pallet-pot"
 version = "0.1.0"
 authors = ["Alex Wang"]
-description = "EVM utils for Magnet."
+description = "Systems and special accounts for storing amounts."
 license = "Apache-2.0"
 homepage = "https://magnet.magport.io/"
 repository.workspace = true
@@ -15,31 +15,23 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
 scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
+mp-system = { path = "../../primitives/system", default-features = false }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false, optional = true}
 frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
 frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
-
-#Frontier FRAME
-pallet-evm-chain-id = { version = "1.0.0-dev", git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.1.0", default-features = false}
-pallet-evm = { version = "6.0.0-dev", git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.1.0", default-features = false}
-
-# Frontier Primitive
-fp-evm = { version = "3.0.0-dev", git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.1.0", default-features = false}
-fp-account = { version = "1.0.0-dev", git = "https://github.com/paritytech/frontier", branch = "polkadot-v1.1.0", default-features = false}
+sp-std = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
 
 [dev-dependencies]
 serde = { version = "1.0.188" }
 
 # Substrate
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
 sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
 pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
 pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
-
 
 [features]
 default = [ "std" ]
@@ -47,8 +39,6 @@ runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
-	"sp-runtime/runtime-benchmarks",
-	"pallet-evm/runtime-benchmarks",
 ]
 std = [
 	"codec/std",
@@ -56,17 +46,15 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"pallet-balances/std",
-	"pallet-timestamp/std",	
+	"pallet-timestamp/std",
 	"scale-info/std",
 	"sp-core/std",
 	"sp-io/std",
+	"sp-std/std",
 	"sp-runtime/std",
-	"pallet-evm/std",
+	"mp-system/std",
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
-	"sp-runtime/try-runtime",
-	"pallet-evm/try-runtime",
 ]
-forbid-evm-reentrancy = ["pallet-evm/forbid-evm-reentrancy"]

--- a/pallets/pot/README.md
+++ b/pallets/pot/README.md
@@ -1,0 +1,13 @@
+# EVM-Utils Pallet
+
+The Pot Pallet provides system and special accounts for storing amounts.
+
+
+## Interface
+
+### Dispatchable Functions
+
+- `deposit` - deposit currency Dot to systems and special accounts.
+
+
+

--- a/pallets/pot/rpc/Cargo.toml
+++ b/pallets/pot/rpc/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "pallet-pot-rpc"
+version = "0.1.0"
+authors = ["Alex Wang"]
+description = "Pot rpc"
+license = "Apache-2.0"
+homepage = "https://magnet.magport.io/"
+repository.workspace = true
+edition.workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
+pallet-pot-runtime-api = { path = "../runtime-api", default-features = false }
+
+# Substrate
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }

--- a/pallets/pot/rpc/src/lib.rs
+++ b/pallets/pot/rpc/src/lib.rs
@@ -1,0 +1,106 @@
+// Copyright (C) Magnet.
+// This file is part of Magnet.
+
+// Magnet is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Magnet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Magnet.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Pot RPC.
+
+use jsonrpsee::{
+	core::RpcResult,
+	proc_macros::rpc,
+	types::error::{CallError, ErrorObject},
+};
+use std::sync::Arc;
+
+use sp_api::ProvideRuntimeApi;
+use sp_blockchain::HeaderBackend;
+use sp_runtime::traits::Block as BlockT;
+
+pub use pallet_pot_runtime_api::PotRPCApi;
+
+/// Pot RPC interface
+#[rpc(client, server)]
+pub trait PotApi<BlockHash> {
+	/// Get pot balance.
+	#[method(name = "pot_balance")]
+	fn pot_balance(&self, pot_name: String, at: Option<BlockHash>) -> RpcResult<u128>;
+	/// Get base balance.
+	#[method(name = "base_balance")]
+	fn base_balance(&self, at: Option<BlockHash>) -> RpcResult<u128>;
+}
+
+///Impl pot rpc
+pub struct Pot<C, P> {
+	/// Shared reference to the client.
+	client: Arc<C>,
+	_marker: std::marker::PhantomData<P>,
+}
+
+impl<C, P> Pot<C, P> {
+	/// Creates a new instance of the Pot Rpc helper.
+	pub fn new(client: Arc<C>) -> Self {
+		Self { client, _marker: Default::default() }
+	}
+}
+
+/// Error type of this RPC api.
+pub enum Error {
+	/// The call to runtime failed.
+	RuntimeError,
+}
+
+impl From<Error> for i32 {
+	fn from(e: Error) -> i32 {
+		match e {
+			Error::RuntimeError => 1,
+		}
+	}
+}
+
+impl<C, Block> PotApiServer<<Block as BlockT>::Hash> for Pot<C, Block>
+where
+	Block: BlockT,
+	C: ProvideRuntimeApi<Block> + HeaderBackend<Block> + Send + Sync + 'static,
+	C::Api: PotRPCApi<Block>,
+{
+	fn pot_balance(&self, pot_name: String, at: Option<Block::Hash>) -> RpcResult<u128> {
+		let api = self.client.runtime_api();
+		let at_hash = at.unwrap_or_else(|| self.client.info().best_hash);
+
+		let res = api
+			.balance_of(at_hash, pot_name)
+			.map_err(|e| map_err(e, "Unable to query pot balance."))?;
+
+		let res = res.map_err(|e| map_err(<&str>::from(e), "Query pot balance error."))?;
+
+		Ok(res)
+	}
+
+	fn base_balance(&self, at: Option<Block::Hash>) -> RpcResult<u128> {
+		let api = self.client.runtime_api();
+		let at_hash = at.unwrap_or_else(|| self.client.info().best_hash);
+
+		let res = api
+			.balance_of_base(at_hash)
+			.map_err(|e| map_err(e, "Unable to query base balance."))?;
+
+		let res = res.map_err(|e| map_err(<&str>::from(e), "Query base balance error."))?;
+
+		Ok(res)
+	}
+}
+
+fn map_err(error: impl ToString, desc: &'static str) -> CallError {
+	CallError::Custom(ErrorObject::owned(Error::RuntimeError.into(), desc, Some(error.to_string())))
+}

--- a/pallets/pot/runtime-api/Cargo.toml
+++ b/pallets/pot/runtime-api/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "pallet-pot-runtime-api"
+version = "0.1.0"
+authors = ["Alex Wang"]
+description = "Pot runtime api"
+license = "Apache-2.0"
+homepage = "https://magnet.magport.io/"
+repository.workspace = true
+edition.workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
+
+# Substrate
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
+
+[features]
+default = [ "std" ]
+std = [
+	"sp-api/std",
+	"sp-runtime/std",
+]

--- a/pallets/pot/runtime-api/src/lib.rs
+++ b/pallets/pot/runtime-api/src/lib.rs
@@ -1,0 +1,30 @@
+// Copyright (C) Magnet.
+// This file is part of Magnet.
+
+// Magnet is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Magnet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Magnet.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![deny(unused_crate_dependencies)]
+
+use scale_info::prelude::string::String;
+
+sp_api::decl_runtime_apis! {
+	/// API for Pot rpc.
+	pub trait PotRPCApi {
+		/// return pot balance
+		fn balance_of(pot_name: String) -> Result<u128, sp_runtime::DispatchError>;
+		/// return base balance
+		fn balance_of_base() -> Result<u128, sp_runtime::DispatchError>;
+	}
+}

--- a/pallets/pot/src/lib.rs
+++ b/pallets/pot/src/lib.rs
@@ -1,0 +1,226 @@
+// Copyright (C) Magnet.
+// This file is part of Magnet.
+
+// Magnet is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Magnet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Magnet.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+use frame_support::traits::{
+	tokens::{fungible::Inspect, ExistenceRequirement},
+	Currency, Get,
+};
+use scale_info::prelude::string::String;
+use sp_core::{crypto::AccountId32, Hasher, H256};
+use sp_std::collections::btree_map::BTreeMap;
+use sp_std::vec::Vec;
+
+pub use self::pallet::*;
+use mp_system::BASE_ACCOUNT;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::{dispatch::DispatchResultWithPostInfo, pallet_prelude::*};
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		/// Pot collect
+		type Pots: Get<BTreeMap<String, Self::AccountId>>;
+		/// Mapping from pot name to account id.
+		type PotNameMapping: PotNameMapping<Self::AccountId>;
+		/// Currency type for balance storage.
+		type Currency: Currency<Self::AccountId> + Inspect<Self::AccountId>;
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		Deposit(T::AccountId, String, BalanceOf<T>),
+		Withdraw(T::AccountId, String, BalanceOf<T>),
+		WithdrawBase(T::AccountId, BalanceOf<T>),
+	}
+
+	#[pallet::error]
+	#[derive(PartialEq)]
+	pub enum Error<T> {
+		DepositFailed,
+		NotPot,
+		TransferFailed,
+	}
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T>
+	where
+		T::AccountId: From<AccountId32>,
+	{
+		#[pallet::call_index(0)]
+		#[pallet::weight(Weight::from_parts(10_000, 0) + T::DbWeight::get().writes(1))]
+		pub fn deposit(
+			origin: OriginFor<T>,
+			pot_name: String,
+			value: BalanceOf<T>,
+		) -> DispatchResultWithPostInfo {
+			let who = ensure_signed(origin)?;
+
+			let name_account_id = Self::ensure_pot(&pot_name)?;
+
+			T::Currency::transfer(&who, &name_account_id, value, ExistenceRequirement::AllowDeath)?;
+
+			Self::deposit_event(Event::Deposit(who, pot_name, value));
+			Ok(().into())
+		}
+
+		#[pallet::call_index(1)]
+		#[pallet::weight(Weight::from_parts(10_000, 0) + T::DbWeight::get().writes(1))]
+		pub fn withdraw(
+			origin: OriginFor<T>,
+			who: T::AccountId,
+			pot_name: String,
+			value: BalanceOf<T>,
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin)?;
+			Self::withdraw_inner(&who, &pot_name, value)?;
+
+			Self::deposit_event(Event::Withdraw(who, pot_name, value));
+			Ok(().into())
+		}
+
+		#[pallet::call_index(2)]
+		#[pallet::weight(Weight::from_parts(10_000, 0) + T::DbWeight::get().writes(1))]
+		pub fn withdraw_base(
+			origin: OriginFor<T>,
+			who: T::AccountId,
+			value: BalanceOf<T>,
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin)?;
+			Self::withdraw_base_inner(&who, value)?;
+
+			Self::deposit_event(Event::WithdrawBase(who, value));
+			Ok(().into())
+		}
+	}
+
+	impl<T: Config> Pallet<T>
+	where
+		T::AccountId: From<AccountId32>,
+	{
+		pub fn ensure_pot(name: &str) -> Result<T::AccountId, Error<T>> {
+			match T::Pots::get().get(name) {
+				Some(account) => Ok(account.clone()),
+				None => Err(Error::<T>::NotPot),
+			}
+		}
+
+		pub fn withdraw_inner(
+			who: &T::AccountId,
+			pot_name: &str,
+			value: BalanceOf<T>,
+		) -> Result<(), Error<T>> {
+			let name_account_id = Self::ensure_pot(pot_name)?;
+
+			let _ = T::Currency::transfer(
+				&name_account_id,
+				&who,
+				value,
+				ExistenceRequirement::AllowDeath,
+			)
+			.map_err(|_| Error::<T>::TransferFailed)?;
+
+			Ok(())
+		}
+
+		pub fn withdraw_base_inner(
+			who: &T::AccountId,
+			value: BalanceOf<T>,
+		) -> Result<(), Error<T>> {
+			let _ = T::Currency::transfer(
+				&<T::AccountId>::from(BASE_ACCOUNT),
+				&who,
+				value,
+				ExistenceRequirement::AllowDeath,
+			)
+			.map_err(|_| Error::<T>::TransferFailed)?;
+
+			Ok(())
+		}
+
+		pub fn balance_of(pot_name: &str) -> Result<BalanceOf<T>, Error<T>> {
+			let name_account_id = Self::ensure_pot(pot_name)?;
+
+			Ok(T::Currency::free_balance(&name_account_id))
+		}
+
+		pub fn balance_of_base() -> Result<BalanceOf<T>, Error<T>> {
+			Ok(T::Currency::free_balance(&<T::AccountId>::from(BASE_ACCOUNT)))
+		}
+	}
+}
+
+pub type BalanceOf<T> =
+	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+
+pub trait PotNameMapping<A> {
+	fn into_account_id(name: &str) -> A;
+}
+
+/// Hashed PotName mapping.
+pub struct HashedPotNameMapping<H>(sp_std::marker::PhantomData<H>);
+
+impl<H: Hasher<Out = H256>> PotNameMapping<AccountId32> for HashedPotNameMapping<H> {
+	fn into_account_id(name: &str) -> AccountId32 {
+		let mut data = String::from("syspot:");
+		data += name;
+		let hash = H::hash(data.as_bytes());
+
+		AccountId32::from(Into::<[u8; 32]>::into(hash))
+	}
+}
+
+pub trait PotNameBtreemap<C> {
+	fn pots_btreemap(names: &[&str]) -> BTreeMap<String, C>;
+}
+
+use sp_std::marker::PhantomData;
+/// Hashed PotName mapping Btree.
+pub struct HashedPotNameBtreemap<C, P>(PhantomData<C>, PhantomData<P>);
+
+impl<C, P> PotNameBtreemap<C::AccountId> for HashedPotNameBtreemap<C, P>
+where
+	C: frame_system::Config,
+	C::AccountId: From<AccountId32>,
+	P: PotNameMapping<AccountId32>,
+{
+	fn pots_btreemap(names: &[&str]) -> BTreeMap<String, C::AccountId> {
+		let mut pots_map = BTreeMap::new();
+		let _: Vec<_> = names
+			.iter()
+			.map(|n| pots_map.insert(String::from(*n), C::AccountId::from(P::into_account_id(n))))
+			.collect();
+
+		pots_map
+	}
+}

--- a/pallets/pot/src/mock.rs
+++ b/pallets/pot/src/mock.rs
@@ -1,0 +1,173 @@
+// Copyright (C) Magnet.
+// This file is part of Magnet.
+
+// Magnet is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Magnet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Magnet.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+
+use frame_support::{
+	dispatch::DispatchClass,
+	parameter_types,
+	traits::{ConstU32, ConstU64, Get},
+	weights::Weight,
+};
+use sp_core::{crypto::AccountId32, H256};
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
+};
+//use frame_system::pallet_prelude::*;
+
+use crate as pallet_pot;
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+	pub enum Test {
+		System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
+		Pot: pallet_pot::{Pallet, Call, Storage, Event<T>},
+	}
+);
+
+parameter_types! {
+	pub(crate) static ExtrinsicBaseWeight: Weight = Weight::zero();
+	pub(crate) static ExistentialDeposit: u64 = 0;
+}
+
+pub struct BlockWeights;
+impl Get<frame_system::limits::BlockWeights> for BlockWeights {
+	fn get() -> frame_system::limits::BlockWeights {
+		frame_system::limits::BlockWeights::builder()
+			.base_block(Weight::zero())
+			.for_class(DispatchClass::all(), |weights| {
+				weights.base_extrinsic = ExtrinsicBaseWeight::get().into();
+			})
+			.for_class(DispatchClass::non_mandatory(), |weights| {
+				weights.max_total = Weight::from_parts(1024, u64::MAX).into();
+			})
+			.build_or_panic()
+	}
+}
+
+pub type AccountId = AccountId32;
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = BlockWeights;
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type Nonce = u64;
+	type RuntimeCall = RuntimeCall;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Block = Block;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<u64>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
+}
+
+impl pallet_balances::Config for Test {
+	type Balance = u64;
+	type RuntimeEvent = RuntimeEvent;
+	type DustRemoval = ();
+	type ExistentialDeposit = ConstU64<1>;
+	type AccountStore = System;
+	type MaxLocks = ();
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 8];
+	type WeightInfo = ();
+	type FreezeIdentifier = ();
+	type MaxFreezes = ();
+	type RuntimeHoldReason = ();
+	type MaxHolds = ();
+}
+
+parameter_types! {
+	pub const MinimumPeriod: u64 = 1;
+}
+
+impl pallet_timestamp::Config for Test {
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	pub const PotNames: [&'static str;3] = ["system", "treasury", "maintenance"];
+	pub Pots: BTreeMap<String, AccountId> = pallet_pot
+											::HashedPotNameBtreemap
+											::<Test, pallet_pot::HashedPotNameMapping<BlakeTwo256>>
+											::pots_btreemap(&(PotNames::get()));
+}
+
+impl pallet_pot::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type PotNameMapping = pallet_pot::HashedPotNameMapping<BlakeTwo256>;
+	type Currency = Balances;
+	type Pots = Pots;
+}
+
+pub const ALICE: AccountId32 = AccountId32::new([21u8; 32]);
+
+pub struct ExtBuilder {
+	existential_deposit: u64,
+}
+
+impl Default for ExtBuilder {
+	fn default() -> Self {
+		Self { existential_deposit: 1 }
+	}
+}
+
+impl ExtBuilder {
+	pub fn existential_deposit(mut self, existential_deposit: u64) -> Self {
+		self.existential_deposit = existential_deposit;
+		self
+	}
+	pub fn set_associated_consts(&self) {
+		EXISTENTIAL_DEPOSIT.with(|v| *v.borrow_mut() = self.existential_deposit);
+	}
+	pub fn build(self) -> sp_io::TestExternalities {
+		self.set_associated_consts();
+		let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+		pallet_balances::GenesisConfig::<Test> { balances: vec![] }
+			.assimilate_storage(&mut t)
+			.unwrap();
+		let mut ext = sp_io::TestExternalities::new(t);
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+}
+
+pub(crate) fn last_event() -> RuntimeEvent {
+	frame_system::Pallet::<Test>::events().pop().expect("Event expected").event
+}
+
+pub(crate) fn expect_event<E: Into<RuntimeEvent>>(e: E) {
+	assert_eq!(last_event(), e.into());
+}

--- a/pallets/pot/src/tests.rs
+++ b/pallets/pot/src/tests.rs
@@ -1,0 +1,83 @@
+// Copyright (C) Magnet.
+// This file is part of Magnet.
+
+// Magnet is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Magnet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Magnet.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+
+use crate::mock::*;
+use frame_support::{assert_noop, assert_ok};
+use Event as PotEvent;
+
+#[test]
+fn deposit_to_pot_works() {
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let _ = Balances::deposit_creating(&ALICE, 10_000_000_000_000);
+
+		assert_noop!(Pot::ensure_pot("ttt"), Error::<Test>::NotPot);
+		assert_ok!(Pot::ensure_pot("treasury"));
+		let treasury = Pot::ensure_pot("treasury").unwrap();
+		let _ = Balances::deposit_creating(&treasury, 10_000_000_000_000);
+
+		let treasury_before = Balances::free_balance(treasury.clone());
+		let deposit_value = 80_000_000_000;
+
+		assert_ok!(Pot::deposit(
+			RuntimeOrigin::signed(ALICE),
+			"treasury".to_string(),
+			deposit_value
+		));
+		expect_event(PotEvent::Deposit(ALICE, "treasury".to_string(), deposit_value));
+		assert_eq!(Balances::free_balance(treasury), treasury_before + deposit_value);
+	})
+}
+
+#[test]
+fn withdraw_from_pot_works() {
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let _ = Balances::deposit_creating(&ALICE, 10_000_000_000_000);
+
+		assert_noop!(Pot::ensure_pot("ttt"), Error::<Test>::NotPot);
+		assert_ok!(Pot::ensure_pot("treasury"));
+		let treasury = Pot::ensure_pot("treasury").unwrap();
+		let _ = Balances::deposit_creating(&treasury, 10_000_000_000_000);
+
+		let treasury_before = Balances::free_balance(treasury.clone());
+		let withdraw_value = 80_000_000_000;
+
+		assert_ok!(Pot::withdraw(
+			RuntimeOrigin::root(),
+			ALICE,
+			"treasury".to_string(),
+			withdraw_value
+		));
+		expect_event(PotEvent::Withdraw(ALICE, "treasury".to_string(), withdraw_value));
+		assert_eq!(Balances::free_balance(treasury), treasury_before - withdraw_value);
+	})
+}
+
+#[test]
+fn withdraw_from_base_works() {
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let _ = Balances::deposit_creating(&ALICE, 10_000_000_000_000);
+		let _ = Balances::deposit_creating(&BASE_ACCOUNT, 10_000_000_000_000);
+
+		let base_before = Balances::free_balance(BASE_ACCOUNT);
+		let withdraw_value = 80_000_000_000;
+
+		assert_ok!(Pot::withdraw_base(RuntimeOrigin::root(), ALICE, withdraw_value));
+		expect_event(PotEvent::WithdrawBase(ALICE, withdraw_value));
+		assert_eq!(Balances::free_balance(BASE_ACCOUNT), base_before - withdraw_value);
+	})
+}

--- a/primitives/system/Cargo.toml
+++ b/primitives/system/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "mp-system"
+version = "0.1.0"
+authors = ["Alex Wang"]
+description = "System trait and type."
+license = "Apache-2.0"
+homepage = "https://magnet.magport.io/"
+repository.workspace = true
+edition.workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+
+# Substrate
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false}
+
+[features]
+default = [ "std" ]
+std = [
+	"sp-api/std",
+	"sp-core/std",
+	"frame-support/std",
+]

--- a/primitives/system/src/lib.rs
+++ b/primitives/system/src/lib.rs
@@ -1,0 +1,46 @@
+// Copyright (C) Magnet.
+// This file is part of Magnet.
+
+// Magnet is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Magnet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Magnet.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![deny(unused_crate_dependencies)]
+
+use frame_support::weights::Weight;
+use sp_core::crypto::AccountId32;
+
+// Base account id b"system:base' and fill with 1u32
+const A: [u8; 32] = [
+	115, 121, 115, 116, 101, 109, 58, 98, 97, 115, 101, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1,
+];
+pub const BASE_ACCOUNT: AccountId32 = AccountId32::new(A);
+
+pub trait Liquidate {
+	fn liquidate() -> Weight;
+}
+
+impl Liquidate for () {
+	fn liquidate() -> Weight {
+		Weight::zero()
+	}
+}
+
+sp_api::decl_runtime_apis! {
+	// API for on_relaychain call
+	pub trait OnRelayChainApi {
+		// return on_relaychain call result, 1 for force bid coretime
+		fn on_relaychain(blocknumber: u32) -> i32;
+	}
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parachain-magnet-runtime"
-version = "0.1.3"
+version = "0.1.6"
 authors = ["Anonymous"]
 description = "A scalable evm smart contract platform runtime, utilizing DOT as the gas fee."
 license = "Apache License 2.0"
@@ -22,11 +22,15 @@ scale-info = { version = "2.9.0", default-features = false, features = ["derive"
 smallvec = "1.11.0"
 
 # Local
+mp-system = { path = "../primitives/system", default-features = false }
 pallet-parachain-template = { path = "../pallets/template", default-features = false }
 pallet-motion = { path = "../pallets/motion", default-features = false }
 pallet-assets-bridge = { path = "../pallets/assets-bridge", default-features = false }
 pallet-evm-utils = { path = "../pallets/evm-utils", default-features = false }
 pallet-precompile-substrate-utils = { path = "../pallets/evm/precompile/substrate-utils", default-features = false }
+pallet-pot = { path = "../pallets/pot", default-features = false }
+pallet-pot-runtime-api = { path = "../pallets/pot/runtime-api", default-features = false }
+pallet-assurance = { path = "../pallets/assurance", default-features = false }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false, optional = true}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -28,6 +28,8 @@ use sp_runtime::{
 	ApplyExtrinsicResult, ConsensusEngineId, MultiSignature,
 };
 
+use scale_info::prelude::string::String;
+use sp_std::collections::btree_map::BTreeMap;
 use sp_std::{marker::PhantomData, prelude::*};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
@@ -44,8 +46,8 @@ use frame_support::{
 	dispatch::DispatchClass,
 	parameter_types,
 	traits::{
-		AsEnsureOriginWithArg, ConstBool, ConstU32, ConstU64, ConstU8, Currency, EitherOfDiverse,
-		Everything, FindAuthor, Imbalance, OnFinalize, OnUnbalanced,
+		AsEnsureOriginWithArg, ConstBool, ConstU128, ConstU32, ConstU64, ConstU8, Currency,
+		EitherOfDiverse, Everything, FindAuthor, Imbalance, OnFinalize, OnUnbalanced,
 	},
 	weights::{
 		constants::WEIGHT_REF_TIME_PER_SECOND, ConstantMultiplier, Weight, WeightToFeeCoefficient,
@@ -94,6 +96,8 @@ use pallet_evm::{
 
 mod precompiles;
 use precompiles::FrontierPrecompiles;
+
+use pallet_pot::PotNameBtreemap;
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = MultiSignature;
@@ -886,6 +890,33 @@ impl pallet_evm_utils::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 }
 
+parameter_types! {
+	pub const PotNames: [&'static str;3] = ["system", "treasury", "maintenance"];
+	pub Pots: BTreeMap<String, AccountId> = pallet_pot
+											::HashedPotNameBtreemap
+											::<Runtime, pallet_pot::HashedPotNameMapping<BlakeTwo256>>
+											::pots_btreemap(&(PotNames::get()));
+}
+
+impl pallet_pot::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type PotNameMapping = pallet_pot::HashedPotNameMapping<BlakeTwo256>;
+	type Currency = Balances;
+	type Pots = Pots;
+}
+
+parameter_types! {
+	pub const SystemPotName: &'static str = "system";
+}
+
+impl pallet_assurance::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type SystemPotName = SystemPotName;
+	type Liquidate = ();
+	type DefaultBidThreshold = ConstU32<8u32>;
+	type DefaultLiquidateThreshold = ConstU128<100_000_000_000_000>;
+}
+
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
 	pub enum Runtime
@@ -933,6 +964,8 @@ construct_runtime!(
 
 		//Magnet
 		EVMUtils: pallet_evm_utils = 60,
+		Pot: pallet_pot = 61,
+		Assurance: pallet_assurance = 62,
 	}
 );
 
@@ -1286,6 +1319,21 @@ impl_runtime_apis! {
 	impl cumulus_primitives_core::CollectCollationInfo<Block> for Runtime {
 		fn collect_collation_info(header: &<Block as BlockT>::Header) -> cumulus_primitives_core::CollationInfo {
 			ParachainSystem::collect_collation_info(header)
+		}
+	}
+
+	impl mp_system::OnRelayChainApi<Block> for Runtime {
+		fn on_relaychain(block_number: u32) -> i32 {
+			Assurance::on_relaychain(block_number)
+		}
+	}
+
+	impl pallet_pot_runtime_api::PotRPCApi<Block> for Runtime {
+		fn balance_of(pot_name: String) -> Result<u128, sp_runtime::DispatchError> {
+			Pot::balance_of(&pot_name).map_err(|_| sp_runtime::DispatchError::Other("NotPot"))
+		}
+		fn balance_of_base() -> Result<u128, sp_runtime::DispatchError> {
+			Pot::balance_of_base().map_err(|_| sp_runtime::DispatchError::Other("BaseBalanceError"))
 		}
 	}
 


### PR DESCRIPTION
The pallet assurance ensure that Magnet can produce blocks even in special cases, such as when the GAS'es fee is less than 
the cost of subscribing to a CoreTime which last for a long period of time. And the pallet pot provide base account and system accounts used for liquidate and other function. The code comprise mainly follow parts:
1. pallet assurance
2. pallet pot
3. Add the unit test code of evm-utils and substrate-utils

close #13 