### PR TITLE
fixed: fixed MinLiquidationThreshold must be greater than ExistentialDeposit error in mock

### DIFF
--- a/pallets/liquidation/src/tests.rs
+++ b/pallets/liquidation/src/tests.rs
@@ -11,7 +11,7 @@ fn distribute_profit_should_work() {
 		.treasury_ratio(Perbill::from_percent(33))
 		.operation_ratio(Perbill::from_percent(25))
 		.collator_ratio(Perbill::from_percent(22))
-		.min_liquidation_threshold(1_000)
+		.min_liquidation_threshold(20_000_000_000)
 		.profit_distribution_cycle(10)
 		.build()
 		.execute_with(|| {


### PR DESCRIPTION
ExistentialDeposit error in mock